### PR TITLE
Implement GDrive/Dropbox link uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,18 @@ CLIENT_TOKEN=YOURTOKENHERE
 GUILD_IDS="[YOUR,GUILD,IDS,HERE]"
 ADMIN_IDS="[YOUR,ADMIN,IDS,HERE]"
 DB="yourdb.db"
+DBX_TOKEN="YOUR_DBX_APP_TOKEN"
 ```
 5. Run `python bot.py`.
 6. ????
 7. You have SantaBot up and running! Hopefully.
+
+If you intend to use or work on Dropbox link downloading, you need to create a new app to get your access token.
+1. Go to [this page](https://www.dropbox.com/developers/apps/create?_tk=pilot_lp&_ad=ctabtn1&_camp=create) to set up a new app on Dropbox.
+2. Select Scoped access -> Full Dropbox and give your app a name, then click `Create app`.
+3. On the app's dashboard, under the Settings tab, generate an access token under `Generated access token` and put that in the .env.
+4. Go to the Permissions tab and set the `sharing.read` permission to on.
+Sorry lol
 
 > [!WARNING]
 > This code is provided as-is. If you need help running the bot, please open an issue as that will be the fastest way for me to see it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 py-cord
 python-dotenv
 aiohttp
+gdown
+dropbox


### PR DESCRIPTION
This PR adds a new command, `/santa linkupload`, which allows users to upload simfile skeletons via a Google Drive or Dropbox link. Some commands have also been given descriptions for their parameters to make the uploading process more clear.

I haven't updated `/santa help` to mention the new upload method because I forgot, oops.

It's still unknown whether Dropbox app tokens expire in 4 hours, or if they last for longer. I'd be fine with axeing that part of the feature if it's too much of a hassle to set up a refresh token (I tried and couldn't get mine...)